### PR TITLE
fix/correct-paths

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -32,6 +32,9 @@ if [[ -n "$ORG" && -n "$REPO" ]]; then
   if [ "$(basename "$PWD")" = ".setup" ]; then
     cd ..
   fi
+  if [ "$(basename "$PWD")" = "base" ]; then
+    cd ..
+  fi
   if [ "$(basename "$PWD")" = "$REPO" ]; then
     cd ..
   fi


### PR DESCRIPTION
This pull request introduces a minor improvement to the directory navigation logic in the `.setup/setup.sh` script. The update ensures that the script correctly moves up one directory when executed from the `base` directory, aligning its behavior with existing checks for other directories.

* Added a check to move up one directory if the current working directory is `base`, improving consistency in setup script navigation.