### PR TITLE
fix/additional-path-checks

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -35,6 +35,12 @@ if [[ -n "$ORG" && -n "$REPO" ]]; then
   if [ "$(basename "$PWD")" = "base" ]; then
     cd ..
   fi
+  if [ "$(basename "$PWD")" = "cros-base" ]; then
+    cd ..
+  fi
+  if [ "$(basename "$PWD")" = "cros-setup" ]; then
+    cd ..
+  fi
   if [ "$(basename "$PWD")" = "$REPO" ]; then
     cd ..
   fi

--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -32,6 +32,9 @@ if [[ -n "$ORG" && -n "$REPO" ]]; then
   if [ "$(basename "$PWD")" = ".setup" ]; then
     cd ..
   fi
+  if [ "$(basename "$PWD")" = "base" ]; then
+    cd ..
+  fi
   if [ "$(basename "$PWD")" = "$REPO" ]; then
     cd ..
   fi

--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -29,24 +29,12 @@ done
 # if the org and repo variables are set
 if [[ -n "$ORG" && -n "$REPO" ]]; then
   sudo apt install -y git
-  if [ "$(basename "$PWD")" = ".setup" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "base" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "cros-base" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "cros-setup" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "$REPO" ]; then
-    cd ..
-  fi
-  if [ "$(basename "$PWD")" = "$ORG" ]; then
-    cd ..
-  fi
+  folders=(".setup" "base" "cros-base" "cros-setup" "$REPO" "$ORG")
+  for folder in "${folders[@]}"; do
+    if [ "$(basename "$PWD")" = "$folder" ]; then
+      cd ..
+    fi
+  done
   mkdir -p "$ORG"
   cd "$ORG"
   if [ ! -d "$REPO" ]; then


### PR DESCRIPTION
This pull request makes a small update to the directory navigation logic in `.setup/setup.sh`. The change adds additional checks to handle more possible directory names when navigating up the directory tree during setup. 

Most important change:

* Added checks for the directories `base`, `cros-base`, and `cros-setup` to ensure the script moves up a level if it is currently in any of these directories.