### PR TITLE
chore/tweak-paths

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -29,7 +29,7 @@ done
 # if the org and repo variables are set
 if [[ -n "$ORG" && -n "$REPO" ]]; then
   sudo apt install -y git
-  folders=(".setup" "base" "cros-base" "cros-setup" "$REPO" "$ORG")
+  folders=(".setup" "base" "$REPO" "$ORG")
   for folder in "${folders[@]}"; do
     if [ "$(basename "$PWD")" = "$folder" ]; then
       cd ..


### PR DESCRIPTION
This pull request makes a minor update to the folder setup process in `.setup/setup.sh`. The change simplifies the folder list used during setup when the `ORG` and `REPO` variables are set.

* Removed the `cros-base` and `cros-setup` folders from the `folders` array, so these directories are no longer included in the setup loop.