### PR TITLE
fix/terminal-input

### DIFF
--- a/.setup/setup.sh
+++ b/.setup/setup.sh
@@ -49,7 +49,7 @@ fi
 # Ensure main branch is checked out
 echo
 echo -ne "${YELLOW}Specify the branch to checkout [main]: ${NC}"
-read BRANCH_NAME
+read BRANCH_NAME < /dev/tty
 echo
 BRANCH_NAME=${BRANCH_NAME:-main}
 git checkout "$BRANCH_NAME"


### PR DESCRIPTION
This pull request makes a minor improvement to the branch selection step in the `.setup/setup.sh` script. The change ensures that user input for the branch name is read directly from the terminal, which helps avoid issues when the script is run in non-interactive environments.